### PR TITLE
Add block to clear queued story parts

### DIFF
--- a/message.ts
+++ b/message.ts
@@ -112,7 +112,6 @@ namespace story {
 
         cancel() {
             this.destroy();
-            this.state = BubbleState.Stopped;
         }
 
         setAlign(left: number, top: number) {
@@ -241,6 +240,7 @@ namespace story {
 
         destroy() {
             game.currentScene().allSprites.removeElement(this);
+            this.stop();
         }
 
         protected updateCore(dtMillis: number) {

--- a/pxt.json
+++ b/pxt.json
@@ -25,7 +25,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "1.2.9",
+        "target": "1.2.10",
         "targetId": "arcade"
     },
     "supportedTargets": [

--- a/sequence.ts
+++ b/sequence.ts
@@ -34,6 +34,10 @@ namespace story {
 
         clear() {
             this.queue = [];
+            for (const task of this.activeTasks) {
+                if (task.cancel)
+                    task.cancel();
+            }
             this.reset();
         }
     }

--- a/sequence.ts
+++ b/sequence.ts
@@ -31,6 +31,11 @@ namespace story {
                 if (task.key === key && task.cancel) task.cancel();
             }
         }
+
+        clear() {
+            this.queue = [];
+            this.reset();
+        }
     }
 
     //% blockId=story_queue_story_part
@@ -40,6 +45,14 @@ namespace story {
     export function queueStoryPart(cb: () => void) {
         init();
         stateStack[stateStack.length - 1].queue.push(cb);
+    }
+
+    //% blockId=story_clear_story_parts
+    //% block="clear queued story parts"
+    //% group="Scene"
+    export function clearQueuedStoryParts() {
+        init();
+        stateStack[stateStack.length - 1].clear();
     }
 
     export function _trackTask(task: Task) {

--- a/shapeSprites.ts
+++ b/shapeSprites.ts
@@ -22,6 +22,9 @@ namespace story {
 
         destroy() {
             game.currentScene().allSprites.removeElement(this);
+            if (this.parent && !this.parent.isDone()) {
+                if (this.parent.cancel) this.parent.cancel();
+            }
         }
 
         __drawCore(camera: scene.Camera) {

--- a/test.ts
+++ b/test.ts
@@ -1,2 +1,12 @@
 // story.printDialog("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.", 80, 60, 1, 15, story.TextSpeed.Fast) 
-story.printDialog("Here is some test text. it's got some punctuation, and i wouldn't love if it didn't break like i expected it too.", 80, 90, 50, 150)
+controller.A.onEvent(ControllerButtonEvent.Pressed, () => {
+    story.clearQueuedStoryParts();
+    game.splash("CLEARED!");
+})
+
+story.queueStoryPart(() => {
+    story.printDialog("Here is some test text. it's got some punctuation, and i wouldn't love if it didn't break like i expected it too.", 80, 90, 50, 150, 0xF, 0x1, story.TextSpeed.VeryFast);
+});
+story.queueStoryPart(() => {
+    story.printDialog("Here is some more text; if you pressed A to clear before this started and it's still showing up, something is wrong :(", 80, 90, 50, 150);
+});


### PR DESCRIPTION
Add a block to clear queued story parts; can't get rid of any currently active one, but this will prevent other ones from continuing event after you clear text / etc

Add block to let you cancel queued story parts; e.g. here the game is 'press a to cancel before you get unhappy faces'

![image](https://user-images.githubusercontent.com/5615930/101672919-4fa1ff00-3a0b-11eb-802b-9ed3dac28006.png)

Also fix bug with clear all text, right now it's freezing the story parts as it destroys the sprites / the associated tasks never get canceled when the sprite is destroyed so it just stops progression.